### PR TITLE
DONT MERGE: Require that 'sync' will be called only from BT

### DIFF
--- a/src/main/resources/base.js
+++ b/src/main/resources/base.js
@@ -122,6 +122,7 @@ function interrupt(es, fn) {
  *
  */
 function sync(stmt, syncData) {
+  testInBThread('sync', true)
   function appendToPart(stmt, field) {
     if (bp.thread.data[field].length === 0) {
       return;
@@ -160,6 +161,16 @@ function sync(stmt, syncData) {
 
 }
 
+let ignoreBThread = false
+
+function startIgnoreBThread() {
+  ignoreBThread = true
+}
+
+function endIgnoreBThread() {
+  ignoreBThread = false
+}
+
 
 /**
  * Returns true iff the function has been called by a b-thread
@@ -168,7 +179,8 @@ function sync(stmt, syncData) {
 function isInBThread() {
   try {
     let a = bp.thread.name
-    return true
+    // BUG: if we remove this comment - it fails!
+    return true && !ignoreBThread
   } catch (ignored) {
     return false
   }

--- a/src/main/resources/context.js
+++ b/src/main/resources/context.js
@@ -207,7 +207,9 @@ const ctx = {
         while (true) {
           let data = sync({waitFor: Any(eventName)}).data
           ctx.beginTransaction()
+          startIgnoreBThread()
           ctx_proxy.effectFunctions.get(key)(data)
+          endIgnoreBThread()
           ctx.endTransaction()
         }
       })


### PR DESCRIPTION
Note: this code contains some strange bug, see comment in `isInBThread`.

Therefore, it's better not to merge it as is. However, it can serve as a basis for an improved code, or even just as a reminder that it should be done in the future...